### PR TITLE
Available translation formats update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Gem can be used in two ways:
 * `api_access_token` - access key to Yata (Organizations Settings > Security > API token)
 * `project_id` - project id you wish to fetch from (Organizations Settings > Security> Projects > Id)
 * `languages` - supported locales, add any locale you wish. Default: `[:en]`
-* `translation_format` - format you wish to get files in, available for now are (yaml, js, json, properties, xml, strings and plist). Default: `json`
+* `translation_format` - format you wish to get files in, available for now are (yaml, js, json, properties, xml, xml_escaped, xml_android_resource, strings and plist). Default: `json`
 * `save_to_path` - you can define where files should be saved. Default: `/config/locales/`
 * `root` - add locale as root to file with translations. Default: `false`
 * `strip_empty` - generates only keys that have text and skip empty ones. Default `false`


### PR DESCRIPTION
Two new versions of XML formats were introduced:
- `xml_escaped` - the same as `xml` but escapes characters like `<`,`>`, `&` and a few others that could break XML formatting;
- `xml_android_resource` - the same as `xml_escaped` but with even more rules to key naming. Specifically, translations key must follow the same rules as Java variable names do due to how string resources are used in Android. This type is capable of outputting partially modified translation keys: `-` and `.` are replaced as `_`, e.g. `this.is.my-key_` will be `this_is_my_key_`. 